### PR TITLE
change the default log filename to /dev/stderr. sparkle-plugin#7.

### DIFF
--- a/include/alps/common/debug_options.hh
+++ b/include/alps/common/debug_options.hh
@@ -22,7 +22,7 @@
 namespace alps {
 
 struct DebugOptions: public Externalizable {
-    std::string kDefaultLogFilename = "sample.log";
+    std::string kDefaultLogFilename = "/dev/stderr";
     std::string kDefaultLogLevel = "error";
 
     /**


### PR DESCRIPTION
This PR changes the debug log filename to /dev/stderr to keep alps from always creating the debug log file.